### PR TITLE
add diff-only updating and support routes

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -6,6 +6,15 @@ Creates a bucket with the specified name and enables static website hosting on i
 
 Your AWS credentials should either be in `~/.aws/credentials` or in the environment variables `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY`.
 
+Your website policy and configuration will only be sent to S3 when it differs
+from the existing.
+
+### Note!
+
+Because of limitations of the S3 API, any changes made to the website policy or
+configuration in the S3 web interface, or elsewhere, will be overwritten by the
+settings provided to `s3-website`.
+
 ### Installation
 
 `s3-website` is a [node.js](http://nodejs.org) program/module.
@@ -28,6 +37,7 @@ $ s3-website -h
     -r, --region <region>                Region [us-east-1]
     -i, --index <index>                  Index Document [index.html]
     -e, --error <error>                  Error Document
+    -t, --routes <routes>                Path to a require'able RoutingRules file
     --json                               Output JSON
     --cert-id <IAM ServerCertId>         The ID of your cert in IAM.
     -c, --cert <cert>                    Path to the public key certificate.
@@ -53,6 +63,14 @@ s3site({
   region: 'eu-central-1', // optional, default: us-east-1
   index: 'index.html', // optional index document, default: index.html
   error: '404.html' // optional error document, default: none
+  routes: [{
+    Condition: {
+        KeyPrefixEquals: 'foo/'
+    },
+    Redirect: {
+        HostName: 'foo.com'
+    }
+  }]
 }, function(err, website) {
   if (err) throw err
   console.log(website)
@@ -61,9 +79,15 @@ s3site({
 
 You can also pass in the same the TLS related options as in [cloudfront-tls](https://github.com/klaemo/cloudfront-tls). So you might want to take a look at its readme if you want to use your own certificates.
 
+### Routing Rules
+
+`RoutingRules` can be provided via cli and API. From the cli you will need to provide the path to
+a file that can be loaded via `require`, that is to say, a `.js` or `.json` file. This file
+should export an array of rules that conform to the [S3 Routing Rules syntax](http://docs.aws.amazon.com/AmazonS3/latest/dev/HowDoIWebsiteConfiguration.html#configure-bucket-as-website-routing-rule-syntax). Likewise, you can provide an
+array of rules to the API with the `routes` option.
+
 ### TODO
 
-- routing setup
 - www -> non-www redirect (via Route 53 hack)
 
 ### License

--- a/cli.js
+++ b/cli.js
@@ -10,6 +10,7 @@ program
   .option('-r, --region <region>', 'Region [us-east-1].')
   .option('-i, --index <index>', 'Index Document [index.html].')
   .option('-e, --error <error>', 'Error Document.')
+  .option('-t, --routes <routes>', 'Routing rules.')
   .option('--json', 'Output JSON.')
   .option('--cert-id <IAM ServerCertId>', 'The ID of your cert in IAM.')
   .option('-c, --cert <cert>', 'Path to the public key certificate.')

--- a/cli.js
+++ b/cli.js
@@ -10,7 +10,7 @@ program
   .option('-r, --region <region>', 'Region [us-east-1].')
   .option('-i, --index <index>', 'Index Document [index.html].')
   .option('-e, --error <error>', 'Error Document.')
-  .option('-t, --routes <routes>', 'Routing rules.')
+  .option('-t, --routes <routes>', 'Path to routing rules file.')
   .option('--json', 'Output JSON.')
   .option('--cert-id <IAM ServerCertId>', 'The ID of your cert in IAM.')
   .option('-c, --cert <cert>', 'Path to the public key certificate.')

--- a/index.js
+++ b/index.js
@@ -200,7 +200,7 @@ function loadRoutes(routesOrFile) {
 }
 
 function validateRoutes(routes) {
-  assert(routes.constructor === Array)
+  assert(Array.isArray(routes), 'Routes must be an array')
 
   var validProperties = {
     Condition: {

--- a/index.js
+++ b/index.js
@@ -93,7 +93,7 @@ module.exports = function(config, cb) {
 
 function createWebsite (s3, websiteConfig, config, cb) {
 
-  function parseWebsite(website) {
+  function parseWebsite(website, modified) {
       var host
 
       // Frankfurt has a slightly differnt URL scheme :(
@@ -110,7 +110,8 @@ function createWebsite (s3, websiteConfig, config, cb) {
 
       return {
         url: siteUrl,
-        config: website
+        config: website,
+        modified: modified ? true : false
       }
   }
 
@@ -120,7 +121,7 @@ function createWebsite (s3, websiteConfig, config, cb) {
 
       s3.getBucketWebsite({ Bucket: config.domain }, function(err, website) {
         if (err) return cb(err)
-        cb(null, parseWebsite(website))
+        cb(null, parseWebsite(website, true))
       })
     })
   }

--- a/package.json
+++ b/package.json
@@ -31,7 +31,9 @@
     "aws-sdk": "^2.1.4",
     "cloudfront-tls": "^1.0.0",
     "commander": "^2.6.0",
-    "merge-defaults": "^0.2.1"
+    "deep-diff": "^0.3.0",
+    "merge-defaults": "^0.2.1",
+    "object-assign": "^2.0.0"
   },
   "devDependencies": {
     "faucet": "0.0.1",

--- a/test/index.js
+++ b/test/index.js
@@ -5,7 +5,15 @@ var AWS = require('aws-sdk')
 
 var config = {
   region: 'eu-central-1',
-  domain: 's3-website-test-' + Math.ceil(Math.random() * 10)
+  domain: 's3-website-test-' + Math.ceil(Math.random() * 10),
+  routes: [{
+    Condition: {
+        KeyPrefixEquals: 'foo/'
+    },
+    Redirect: {
+        HostName: 'example.com'
+    }
+  }]
 }
 
 test('create website', function(t) {


### PR DESCRIPTION
Adding in two features:
- Compare original policy and `WebsiteConfiguration` via deep-diff, only perform action when a diff is found (speeds things up significantly, and makes me less jittery)
- Passing a `config.routes` array through to `WebsiteConfiguration` as `RoutingRules` prop. I didn't attempt any change in the AWS idiom here. I think their docs are clear and the features very easy to use --  it would only add support overhead if I tried to make something more "user-friendly"

I also added the routes to the test, so that feature is being integration tested.

For the future: I think it would be ideal to merge the diffs, in case the user made modifications elsewhere, but without version info from AWS I'm not sure this is feasible.

It also might be good to provide assertions for valid AWS `RoutingRules`, but I'll wait until I hear back about this PR.
