### PR TITLE
remove default routingrules array which seems to cause schema validat…

### DIFF
--- a/index.js
+++ b/index.js
@@ -21,8 +21,7 @@ var defaultWebsiteConfig = {
   WebsiteConfiguration: { /* required */
     IndexDocument: {
       Suffix: defaultConfig.index /* required */
-    },
-    RoutingRules: []
+    }
   }
 }
 


### PR DESCRIPTION
I started getting schema validation errors coming out of the aws sdk when not providing routes to s3-website. Removing the default empty array solved the problem. This might be an underlying change, or addition of schema validations in the sdk.
