### PR TITLE
Add Large Upload Support

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,11 @@
   "version": "2.1.0",
   "description": "Easily publish static websites on Amazon S3",
   "main": "index.js",
-  "scripts": {},
+  "scripts": {
+    "test": "node test/index.js | faucet",
+    "lint": "snazzy",
+    "prepublish": "npm prune && npm ls && npm run lint && npm test"
+  },
   "bin": {
     "s3-website": "./s3-website.js"
   },

--- a/package.json
+++ b/package.json
@@ -3,11 +3,7 @@
   "version": "2.1.0",
   "description": "Easily publish static websites on Amazon S3",
   "main": "index.js",
-  "scripts": {
-    "test": "node test/index.js | faucet",
-    "lint": "snazzy",
-    "prepublish": "npm prune && npm ls && npm run lint && npm test"
-  },
+  "scripts": {},
   "bin": {
     "s3-website": "./s3-website.js"
   },
@@ -37,6 +33,8 @@
     "deep-diff": "^0.3.4",
     "dotenv": "^2.0.0",
     "glob": "^7.1.1",
+    "graceful-fs": "^4.1.11",
+    "lodash": "^4.17.4",
     "log-update": "^1.0.2",
     "merge-defaults": "^0.2.1",
     "mime": "^1.3.4",

--- a/test/index.js
+++ b/test/index.js
@@ -1,6 +1,7 @@
 var test = require('tape')
 var supertest = require('supertest')
 var s3site = require('../').s3site
+var s3Utils = require('../').utils
 var AWS = require('aws-sdk')
 
 var config = {
@@ -152,6 +153,20 @@ test('update website', function (t) {
       t.pass('deleted ' + config.domain)
       t.end()
     })
+  })
+})
+
+test('sequentially', function (t) {
+  var counter = 0
+  var action = function (s3, config, file, cb) {
+    counter++
+    cb()
+  }
+  var arr = [1, 2, 3, 4, 5]
+
+  s3Utils.sequentially(null, null, action, arr, function () {
+    t.equal(counter, 5)
+    t.end()
   })
 })
 


### PR DESCRIPTION
When large numbers of files are uploaded, a 'Too many files' open exception is thrown. This adds support for arbitrary numbers of files, along with request time out retries.