### PR TITLE
Add an exception region to parseWebsite

### DIFF
--- a/index.js
+++ b/index.js
@@ -302,7 +302,8 @@ function parseWebsite (website, modified, config) {
   var host
 
   // Some region has a slightly differnt URL scheme :(
-  var hasDifferentScheme = ['eu-central-1', 'ap-northeast-2'].find(function (region) {
+  var dotEndpointRegions = ['us-east-2', 'ca-central-1', 'ap-south-1', 'ap-northeast-2', 'eu-central-1', 'eu-west-2']
+  var hasDifferentScheme = dotEndpointRegions.find(function (region) {
     return region === config.region
   })
 

--- a/index.js
+++ b/index.js
@@ -301,8 +301,12 @@ function s3site (config, cb) {
 function parseWebsite (website, modified, config) {
   var host
 
-  // Frankfurt has a slightly differnt URL scheme :(
-  if (config.region === 'eu-central-1') {
+  // Some region has a slightly differnt URL scheme :(
+  var hasDifferentScheme = ['eu-central-1', 'ap-northeast-2'].find(function (region) {
+    return region === config.region
+  })
+
+  if (hasDifferentScheme) {
     host = [config.domain, 's3-website', config.region, 'amazonaws.com'].join('.')
   } else {
     host = [config.domain, 's3-website-' + config.region, 'amazonaws.com'].join('.')


### PR DESCRIPTION
First of all, thanks for a useful library.

I found that `ap-northeast-2` also has different URL scheme.
Please review :)