### PR TITLE
3.1.1 add --exclude option

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -73,6 +73,7 @@ create({
   region: 'eu-central-1', // optional, default: us-east-1
   index: 'index.html', // optional index document, default: index.html
   error: '404.html', // optional error document, default: none
+  exclude: ['.git/*', '.gitignore'], // optional path patterns to be excluded from being created/updated/removed, default: [], `*` is the wildcard
   routes: [{
     Condition: {
         KeyPrefixEquals: 'foo/'
@@ -138,6 +139,7 @@ create({
 - [rgruesbeck](https://github.com/rgruesbeck)
 - [nick-benoit14](https://github.com/nick-benoit14)
 - [simoncurd](https://github.com/simoncurd)
+- [StaymanHou](https://github.com/StaymanHou)
 
 ### License
 ISC

--- a/index.js
+++ b/index.js
@@ -11,6 +11,7 @@ var fs = require('graceful-fs')
 var mime = require('mime')
 require('dotenv').config({ silent: true })
 var s3diff = require('s3-diff')
+var wildcard = require('wildcard')
 var logUpdate = require('log-update')
 var array = require('lodash/array')
 
@@ -19,6 +20,7 @@ var defaultConfig = {
   region: 'us-east-1',
   uploadDir: '.',
   prefix: '',
+  exclude: [],
   corsConfiguration: [],
   enableCloudfront: false,
   retries: 20
@@ -510,6 +512,16 @@ function putWebsiteContent (s3, config, cb) {
     recursive: true
   }, function (err, data) {
     if (err) return cb(err)
+
+    // exclude files from the diff
+    config.exclude.forEach(function (excludePattern) {
+      for (var key in data) {
+        data[key] = data[key].filter(function (path) {
+          return !wildcard(excludePattern, path)
+        })
+      }
+    })
+
     var results = {
       uploaded: [],
       updated: [],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "s3-website",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "description": "Easily publish static websites on Amazon S3",
   "main": "index.js",
   "scripts": {
@@ -43,7 +43,8 @@
     "merge-defaults": "^0.2.1",
     "mime": "^1.3.4",
     "object-assign": "^4.1.0",
-    "s3-diff": "^1.1.0"
+    "s3-diff": "^1.1.0",
+    "wildcard": "^1.1.2"
   },
   "devDependencies": {
     "faucet": "0.0.1",

--- a/s3-website.js
+++ b/s3-website.js
@@ -69,6 +69,11 @@ function printDeployResults (err, website, results) {
   }
 }
 
+function exclude (val, excludedList) {
+  excludedList.push(val)
+  return excludedList
+}
+
 program
   .usage('<command> [option]')
   .description(
@@ -110,6 +115,7 @@ program
   .option('-l, --lock-config', 'Will prevent config file from being changed')
   .option('--intermediate <intermediate certs>', 'Path to the concatenated intermediate certificates.')
   .option('-f, --config-file <file>', 'Path to the config file to read. Default is .s3-website.json')
+  .option('--exclude <path-pattern>', 'Path pattern to excluded files from being created/updated/removed. This option is repeatable', exclude, [])
   .action(function (domain, options) {
     var fromCL = getCLArguments({domain: domain}, options)
     if (fromCL.configFile == null) fromCL.configFile = '.s3-website.json'
@@ -153,6 +159,7 @@ program
     '-f, --config-file <file>',
     'Path to the config file to read. Default is .s3-website.json. Note: Using non-standard config file will require passing "-f myConfigFile" with subsequent operations'
   )
+  .option('--exclude <path-pattern>', 'Path pattern to excluded files from being created/updated/removed. This option is repeatable', exclude, [])
   .action(function (uploadDir, options) {
     var fromCL = getCLArguments({uploadDir: uploadDir}, options)
     if (fromCL.configFile == null) fromCL.configFile = '.s3-website.json'

--- a/test/index.js
+++ b/test/index.js
@@ -5,7 +5,7 @@ var s3Utils = require('../').utils
 var AWS = require('aws-sdk')
 
 var config = {
-  region: 'eu-central-1',
+  region: 'eu-central-1', // us-east-1
   domain: 's3-website-test-' + Math.random().toString(16).slice(2),
   routes: [{
     Condition: {
@@ -63,7 +63,7 @@ test('upload content', function (t) {
   })
 })
 
-test('create www redirect', function (t) {
+test.skip('create www redirect', function (t) {
   var subdomain = 'www.' + config.domain
   var destination = 'http://' + config.domain + '/'
 
@@ -92,7 +92,7 @@ test('create www redirect', function (t) {
   })
 })
 
-test('update only changed files', function (t) {
+test.skip('update only changed files', function (t) {
   config.uploadDir = './test/fixtures'
   config.index = 'test-upload.html'
   s3site(config, function (err, website, results) {
@@ -136,6 +136,24 @@ test('upload content with prefix', function (t) {
       .expect('content-type', /html/)
       .expect(/Howdy/)
       .end(t.end)
+  })
+})
+
+test('rollback website with previous prefix path excluded', function (t) {
+  config.prefix = ''
+  config.exclude = ['prefix/folder/*']
+
+  s3site(config, function (err, website) {
+    if (err) cleanup(config.domain)
+    t.error(err, 'website rolled back')
+    console.log(website.url)
+    setTimeout(function () {
+      supertest(website.url).get('/prefix/folder/another.txt')
+        .expect(200)
+        .expect('content-type', /text/)
+        .expect(/Test upload file/)
+        .end(t.end)
+    }, 2000)
   })
 })
 

--- a/test/index.js
+++ b/test/index.js
@@ -63,7 +63,7 @@ test('upload content', function (t) {
   })
 })
 
-test.skip('create www redirect', function (t) {
+test('create www redirect', function (t) {
   var subdomain = 'www.' + config.domain
   var destination = 'http://' + config.domain + '/'
 
@@ -92,7 +92,7 @@ test.skip('create www redirect', function (t) {
   })
 })
 
-test.skip('update only changed files', function (t) {
+test('update only changed files', function (t) {
   config.uploadDir = './test/fixtures'
   config.index = 'test-upload.html'
   s3site(config, function (err, website, results) {


### PR DESCRIPTION
Add a `--exclude` option to exclude files from being created/updated/removed with a bash-style wildcard matching.

This option behaves similarly with the one of rsync.