### PR TITLE
set exclude list to empty array if not provided in config

### DIFF
--- a/index.js
+++ b/index.js
@@ -514,7 +514,8 @@ function putWebsiteContent (s3, config, cb) {
     if (err) return cb(err)
 
     // exclude files from the diff
-    config.exclude.forEach(function (excludePattern) {
+    var excludedFiles = config.exclude || [];
+    excludedFiles.forEach(function (excludePattern) {
       for (var key in data) {
         data[key] = data[key].filter(function (path) {
           return !wildcard(excludePattern, path)


### PR DESCRIPTION
A call to deploy will fail on `config.exclude.forEach` if an `exclude` list is not provided in the input config. This change will guard against that error case.