### PR TITLE
merge provided config with default values at the start of deploy

### DIFF
--- a/index.js
+++ b/index.js
@@ -500,6 +500,8 @@ function uploadFiles (s3, config, files, cb, results = {done: [], errors: []}) {
 function putWebsiteContent (s3, config, cb) {
   if (typeof cb !== 'function') { cb = function () {} }
 
+  config = defaults(config, defaultConfig)
+
   s3diff({
     aws: {
       signatureVersion: 'v4'


### PR DESCRIPTION
As discussed in https://github.com/klaemo/s3-website/pull/36, default values are currently not being provided at the start of `deploy`. This causes issues if any values are omitted in the passed in config.

The solution is to merge the provided config with the defaultConfig.