### PR TITLE
Fix for deploy on windows.

### DIFF
--- a/index.js
+++ b/index.js
@@ -493,8 +493,12 @@ function getConfig (path, fromCL, cb) {
   })
 }
 
+function normalizePath(path) {
+  return path.replace(/\\/g,'/');
+}
+
 function normalizeKey (prefix, key) {
-  return prefix ? prefix + '/' + key : key
+  return normalizePath( prefix ? prefix + '/' + key : key );
 }
 
 function deleteFiles (s3, config, files, cb, results = {done: [], errors: []}) {


### PR DESCRIPTION
This normalizes the slash direction in keys for deploy on windows. If you are already deployed, you will need to clean your bucket of any files containing the slash characters before attempting to deploy. I can now deploy a "React" website from my windows box.