### PR TITLE
Goldpbear/content encoding

### DIFF
--- a/index.js
+++ b/index.js
@@ -23,7 +23,8 @@ var defaultConfig = {
   exclude: [],
   corsConfiguration: [],
   enableCloudfront: false,
-  retries: 20
+  retries: 20,
+  gzippedFiles: []
 }
 
 var templateConfig = Object.assign({},
@@ -187,7 +188,8 @@ function uploadFile (s3, config, file, cb) {
     Key: normalizeKey(config.prefix, file),
     Body: fs.createReadStream(path.join(config.uploadDir, file)),
     ContentType: contentType || mime.lookup(file),
-    CacheControl: (config.cacheControl != null) ? config.cacheControl : null
+    CacheControl: (config.cacheControl != null) ? config.cacheControl : null,
+    ContentEncoding: config.gzippedFiles.includes(file) ? "gzip" : null
   }
 
   logUpdate('Uploading: ' + file)

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   "homepage": "https://github.com/klaemo/s3-website",
   "dependencies": {
     "aws-sdk": "^2.6.12",
-    "cloudfront-tls": "^1.0.0",
+    "cloudfront-tls": "github:mapseed/cloudfront-tls#d9c972ce83afd196e0447232b83d7cd89dfe6889",
     "colors": "^1.1.2",
     "commander": "^2.9.0",
     "console.table": "^0.7.0",


### PR DESCRIPTION
This PR allows us to pass in an array of filepaths which should be uploaded to S3 with the `ContentEncoding` metadata set to `gzip`. This helps avoid a major deployment bug described in https://github.com/jalMogo/mgmt/issues/266.