### PR TITLE
set colors package to 1.4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   "dependencies": {
     "aws-sdk": "^2.6.12",
     "cloudfront-tls": "^1.0.0",
-    "colors": "^1.1.2",
+    "colors": "1.4.0",
     "commander": "^2.9.0",
     "console.table": "^0.7.0",
     "deep-diff": "^0.3.4",


### PR DESCRIPTION
This PR is to solve https://github.com/klaemo/s3-website/issues/64. Basically the author of `colors` package has gone rouge and injected a bomb into the code. Read more about it here: https://github.com/Marak/colors.js/issues/285.

Downgrading the `colors` package to a stable working one is the fix here.